### PR TITLE
Better fix for #3

### DIFF
--- a/src/angular-workers/angular-runner.ts
+++ b/src/angular-workers/angular-runner.ts
@@ -1,6 +1,7 @@
 import { KarmaHelper } from "../karma-workers/karma-helper";
 import explorerKarmaConfig = require("../config/test-explorer-karma.conf");
 import path = require("path");
+import { spawn } from "child_process";
 
 export class AngularRunner {
   private readonly karmaHelper: KarmaHelper;
@@ -42,13 +43,15 @@ export class AngularRunner {
   }
 
   private runNgTest(): void {
-    const cliArgs = ["test", `--karma-config="${require.resolve(this.baseKarmaConfigFilePath)}"`];
-    const command = `ng ${cliArgs.join(" ")} >/dev/null`;
-    global.console.log(`Starting Angular tests: ${command}`);
 
-    const exec = require("child_process").exec;
-    exec(command, {
-      cwd: this.angularProjectRootPath,
-    });
+    const cliArgs = ["test", `--karma-config="${require.resolve(this.baseKarmaConfigFilePath)}"`];
+    console.log(`Starting Angular tests with arguments: ${cliArgs.join(" ")}`);
+
+    const cp = spawn("ng", cliArgs, { cwd: this.angularProjectRootPath, shell: true });
+
+//    cp.stdout.on('data', data => console.log(`stdout: ${data}`));
+//    cp.stderr.on('data', data => console.log(`stderr: ${data}`));
+    cp.on('error', err => console.log(`error from ng child process: ${err}`));
+    cp.on('exit', (code, signal) => console.log(`ng child process exited with code ${code} and signal ${signal}`));
   }
 }


### PR DESCRIPTION
I have found the reason for #3: the `child_process.exec()` function buffers `stdout` and `stderr` from the child process and limits the amount of data that can be buffered. The [documentation](https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_exec_command_options_callback) for the `maxBuffer` option says:

> Largest amount of data in bytes allowed on stdout or stderr. If exceeded, the child process is terminated.

So, if `ng` is started using `child_process.exec()`, it will always eventually be terminated when the buffer is full.

This fix starts `ng` with `child_process.spawn()` instead. Another potential benefit is that `child_process.spawn()` can [set up a communication channel](https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_options_stdio), so that the angular reporter could send its events to the adapter using [`process.send()`](https://nodejs.org/dist/latest-v10.x/docs/api/process.html#process_process_send_message_sendhandle_options_callback) (that's what I use in my adapters as well) instead of `socket.io`. And it's much cleaner than the workaround I found previously.