### PR TITLE
using fork instead of spawn seems to work better on windows

### DIFF
--- a/src/workers/angular/angular-server.ts
+++ b/src/workers/angular/angular-server.ts
@@ -1,7 +1,7 @@
 import { KarmaHelper } from "../karma/karma-helper";
 import explorerKarmaConfig = require("../../config/test-explorer-karma.conf");
 import path = require("path");
-import { spawn, StdioOptions } from "child_process";
+import { fork, StdioOptions } from "child_process";
 
 export class AngularServer {
   private readonly karmaHelper: KarmaHelper;
@@ -61,16 +61,16 @@ export class AngularServer {
   }
 
   private runNgTest(): void {
-    const cliArgs = ["test", `--karma-config="${require.resolve(this.baseKarmaConfigFilePath)}"`];
+    const cliArgs = ["test", `--karma-config=${require.resolve(this.baseKarmaConfigFilePath)}`];
     global.console.log(`Starting Angular tests with arguments: ${cliArgs.join(" ")}`);
 
     const options = {
       stdio: ["pipe", "pipe", "pipe", "ipc"] as StdioOptions,
       cwd: this.angularProjectRootPath,
-      shell: true
+      execArgv: []
     };
 
-    this.angularProcess = spawn("ng", cliArgs, options);
+    this.angularProcess = fork("node_modules/@angular/cli/lib/init.js", cliArgs, options);
 
     this.angularProcess.stdout.on('data', (data: any) => global.console.log(`stdout: ${data}`));
     this.angularProcess.stderr.on('data', (data: any) => global.console.log(`stderr: ${data}`));


### PR DESCRIPTION
This PR tries to fix #9 by using `fork` instead of `spawn`.
It seems to work (the child process runs and communicates using the IPC channel), but it also seems to create new problems: in one test project I got an error message from `ng` that I wasn't getting before and the tests were not loaded in that case.